### PR TITLE
Add methods that encapsulate the "get Compound/ComparisonPredicate by

### DIFF
--- a/bundles/org.eclipse.swt/Eclipse SWT TrueShip/cocoa/org/eclipse/swt/predicate/Predicate.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT TrueShip/cocoa/org/eclipse/swt/predicate/Predicate.java
@@ -51,8 +51,22 @@ public class Predicate {
         return nsPredicate.isKindOfClass(OS.class_NSComparisonPredicate);
     }
     
+    public ComparisonPredicate getComparisonPredicate() {
+    	if (!isComparisonPredicate()) {
+    		throw new IllegalStateException("Not a comparison predicate!");
+    	}
+    	return new ComparisonPredicate(id());
+    }
+    
     public boolean isCompoundPredicate() {
         return nsPredicate.isKindOfClass(OS.class_NSCompoundPredicate);
+    }
+    
+    public CompoundPredicate getCompoundPredicate() {
+    	if (!isCompoundPredicate()) {
+    		throw new IllegalStateException("Not a compound predicate!");
+    	}
+    	return new CompoundPredicate(id());
     }
     
     @Override

--- a/bundles/org.eclipse.swt/Eclipse SWT TrueShip/cocoa/org/eclipse/swt/predicate/Predicate.java
+++ b/bundles/org.eclipse.swt/Eclipse SWT TrueShip/cocoa/org/eclipse/swt/predicate/Predicate.java
@@ -52,10 +52,10 @@ public class Predicate {
     }
     
     public ComparisonPredicate getComparisonPredicate() {
-    	if (!isComparisonPredicate()) {
-    		throw new IllegalStateException("Not a comparison predicate!");
-    	}
-    	return new ComparisonPredicate(id());
+        if (!isComparisonPredicate()) {
+            throw new IllegalStateException("Not a comparison predicate!");
+        }
+        return new ComparisonPredicate(id());
     }
     
     public boolean isCompoundPredicate() {
@@ -63,10 +63,10 @@ public class Predicate {
     }
     
     public CompoundPredicate getCompoundPredicate() {
-    	if (!isCompoundPredicate()) {
-    		throw new IllegalStateException("Not a compound predicate!");
-    	}
-    	return new CompoundPredicate(id());
+        if (!isCompoundPredicate()) {
+    	    throw new IllegalStateException("Not a compound predicate!");
+        }
+        return new CompoundPredicate(id());
     }
     
     @Override


### PR DESCRIPTION
id" behavior so that I don't have to implement this in non-cocoa
predicate editor.
